### PR TITLE
Revert "Copy certificates to the container"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN curl --silent --fail --location --retry 3 --output /tmp/installer.php --url 
  && rm -f /tmp/installer.php \
  && find /tmp -type d -exec chmod -v 1777 {} +
 
-COPY /etc/ssl/certs/ /etc/ssl/certs/
 COPY data/php/uploads.ini /usr/local/etc/php/conf.d/uploads.ini
 COPY data/sites /template/sites
 RUN mkdir -p /app/shared


### PR DESCRIPTION
This reverts commit 1fd6d5d79b1fe6c09aa894ee14fa180decd3fb8a.
This was inherently wrong - the COPY command is relative. The
correct solution is outside the scope of this project.