### PR TITLE
Added imgproxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,17 @@
 version: '3.5'
 
 services:
+  imgproxy:
+    image: darthsim/imgproxy
+    ports:
+      - 8080:8080
+    volumes:
+      - ./app/shared/sites:/app/shared/sites
+    environment:
+      IMGPROXY_ENABLE_WEBP_DETECTION: 1
+      IMGPROXY_ENFORCE_WEBP: 1
+      IMGPROXY_LOCAL_FILESYSTEM_ROOT: /app/shared/
+      IMGPROXY_BASE_URL: local:///
 
   drupal:
     build: .


### PR DESCRIPTION
To test:
- Spin up docker
- Get an image link from your local drupal (the link should look like: sites/default/files/inline-images/someimage.jpg)
- in javascript, use btoa to make it a base64 hash: (`btoa('sites/default/files/inline-images/balcony.jpg')`) and copy the output
- Go to this url with the base64 string: http://localhost:8080/insecure/fill/1200/400/sm/0/<HERE_THE_BASE64>.jpg.