### PR TITLE
(Chore) Update on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ An instance's configuration can be exported from `{{CMS_URL}}/admin/config/devel
 make import_config
 ```
 
+After importing the database of configuration, make sure to run the update command to fix any broken references:
+
+```
+make update
+```
+
 Both the commands `import_db` and `import_config`
 
 ## Updating or requiring modules

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,5 +8,7 @@ cp -rv /template/sites/* /app/shared/sites/
 chown -R www-data:www-data /app/shared/*
 chown -R www-data:www-data /app/config
 
+cd /opt/drupal/web && make update
+
 # Startup Script
 apache2-foreground


### PR DESCRIPTION
This change in this PR will update the database (if necessary) whenever the CMS gets redeployed. This to ensure that there are no outdated references.