### PR TITLE
(Chore) Downgrade deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,11 @@ help: ## show this help screen
 info: ## dump Makefile variables to screen
 	@echo -e $(_MAKEFILE_VARIABLES)
 
+build_nocache: ## Build the container by pulling the image from source instead from cache
+	docker-compose build --pull --no-cache
+
 build: ## build Docker Compose images
-	docker-compose build --pull
+	docker-compose build
 
 start: ## start single Docker Compose service in detached mode
 	docker-compose up -d

--- a/composer.json
+++ b/composer.json
@@ -49,17 +49,14 @@
     },
     "require": {
         "composer/installers": "^1.8",
-        "drupal/console": "^1.9.5",
-        "drupal/core-composer-scaffold": "^9",
-        "drupal/core-project-message": "^9",
-        "drupal/core-recommended": "^8",
-        "drush/drush": "^10.3",
-        "nodespark/des-connector": "^6.0",
-        "webonyx/graphql-php": "v14.3.0",
         "drupal/backup_migrate": "^4.1",
         "drupal/config_update": "^1.7",
+        "drupal/console": "^1.9.5",
         "drupal/consumer_image_styles": "^3.0",
         "drupal/consumers": "^1.11",
+        "drupal/core-composer-scaffold": "^8",
+        "drupal/core-project-message": "^8",
+        "drupal/core-recommended": "^8",
         "drupal/devel": "^4.0",
         "drupal/devel_entity_updates": "^3.0",
         "drupal/elasticsearch_connector": "^6.0",
@@ -74,6 +71,9 @@
         "drupal/search_api": "^1.17",
         "drupal/typed_data": "^1.0",
         "drupal/upgrade_status": "^3.0",
-        "drupal/uuid_extra": "^2.0.0"
+        "drupal/uuid_extra": "^2.0.0",
+        "drush/drush": "^10.3",
+        "nodespark/des-connector": "^6.0",
+        "webonyx/graphql-php": "v14.3.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2500a7b5869ed229248f7890740643e8",
+    "content-hash": "c74ec7172e485b0b8398c82151558bdb",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2475,21 +2475,21 @@
         },
         {
             "name": "drupal/core-composer-scaffold",
-            "version": "9.0.7",
+            "version": "8.9.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-composer-scaffold.git",
-                "reference": "c017751a6bb9b2ffe56f0fab607ba67c21604bfd"
+                "reference": "c902d07cb49ef73777e2b33a39e54c2861a8c81d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-composer-scaffold/zipball/c017751a6bb9b2ffe56f0fab607ba67c21604bfd",
-                "reference": "c017751a6bb9b2ffe56f0fab607ba67c21604bfd",
+                "url": "https://api.github.com/repos/drupal/core-composer-scaffold/zipball/c902d07cb49ef73777e2b33a39e54c2861a8c81d",
+                "reference": "c902d07cb49ef73777e2b33a39e54c2861a8c81d",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1 || ^2",
-                "php": ">=7.3.0"
+                "php": ">=7.0.8"
             },
             "conflict": {
                 "drupal-composer/drupal-scaffold": "*"
@@ -2518,25 +2518,25 @@
             "keywords": [
                 "drupal"
             ],
-            "time": "2020-08-07T22:30:24+00:00"
+            "time": "2020-08-07T22:30:30+00:00"
         },
         {
             "name": "drupal/core-project-message",
-            "version": "9.0.7",
+            "version": "8.9.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-project-message.git",
-                "reference": "fbb9d944f82a1f25ab967a8bc22d3dc19479bd11"
+                "reference": "3f8fa28128f1fef68ee0e6647011a543ef92be5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-project-message/zipball/fbb9d944f82a1f25ab967a8bc22d3dc19479bd11",
-                "reference": "fbb9d944f82a1f25ab967a8bc22d3dc19479bd11",
+                "url": "https://api.github.com/repos/drupal/core-project-message/zipball/3f8fa28128f1fef68ee0e6647011a543ef92be5b",
+                "reference": "3f8fa28128f1fef68ee0e6647011a543ef92be5b",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.1 || ^2",
-                "php": ">=7.3.0"
+                "php": ">=7.0.8"
             },
             "type": "composer-plugin",
             "extra": {
@@ -2556,7 +2556,7 @@
             "keywords": [
                 "drupal"
             ],
-            "time": "2020-08-02T22:04:44+00:00"
+            "time": "2020-08-02T22:04:49+00:00"
         },
         {
             "name": "drupal/core-recommended",


### PR DESCRIPTION
This PR downgrades specific composer dependencies to their `^8` versions instead of their latest (9) versions; we're not using Drupal 9, yet.