### PR TITLE
(Chore) CORS headers

### DIFF
--- a/data/sites/default/services.yml
+++ b/data/sites/default/services.yml
@@ -1,0 +1,9 @@
+parameters:
+  cors.config:
+    enabled: true
+    allowedHeaders: ['accept', 'authorization', 'origin']
+    allowedMethods: ['GET']
+    allowedOrigins: ['https://data.amsterdam.nl', 'https://acc.data.amsterdam.nl', 'http://localhost:3000']
+    exposedHeaders: false
+    maxAge: false
+    supportsCredentials: false


### PR DESCRIPTION
This PR contains changes to the Drupal configuration that allows requests from only three domains. It also set specific headers so that authenticated requests can be received.