### PR TITLE
(Chore) Adds search-api dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,4 @@ RUN mkdir /var/log/apache2/drupal/
 COPY data/apache/000-default.conf /etc/apache2/sites-available/000-default.conf
 RUN a2enmod proxy proxy_http cache_disk headers
 
-ENTRYPOINT [ "/entrypoint.sh" ]
+CMD [ "/entrypoint.sh" ]

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,6 @@ shell: ## execute command on container. Usage: make CONTAINER=database shell
 
 import_db: ## import postgres database. Usage: make DB_FILE=psql.gz import_db
 ifdef DB_FILE
-	## @docker-compose exec -T database dropdb --if-exists -e -U postgres cms
 	@docker-compose exec -T database pg_restore -C --clean --no-acl --no-owner --username=postgres -d postgres < ${DB_FILE}
 else
 	@echo -e "No filename given for database source file"

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
         "drupal/jsonapi_extras": "^3.14",
         "drupal/paragraphs": "^1.12",
         "drupal/rest_absolute_urls": "^1.0@beta",
+        "drupal/search_api": "^1.17",
         "drupal/typed_data": "^1.0",
         "drupal/upgrade_status": "^3.0",
         "drupal/uuid_extra": "^2.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "664e33ee910d5c88c9d3e395d57f90fa",
+    "content-hash": "9b1a66c50b06236d1338e5f1eb665f10",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -3693,6 +3693,78 @@
             "homepage": "https://www.drupal.org/project/rest_absolute_urls",
             "support": {
                 "source": "https://git.drupalcode.org/project/rest_absolute_urls"
+            }
+        },
+        {
+            "name": "drupal/search_api",
+            "version": "1.18.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/search_api.git",
+                "reference": "8.x-1.18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/search_api-8.x-1.18.zip",
+                "reference": "8.x-1.18",
+                "shasum": "6cf1d6820ba55891e204bac40b6031ed15db482a"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9"
+            },
+            "conflict": {
+                "drupal/search_api_solr": "2.* || 3.0 || 3.1"
+            },
+            "require-dev": {
+                "drupal/language_fallback_fix": "@dev",
+                "drupal/search_api_autocomplete": "@dev",
+                "drupal/search_api_db": "*"
+            },
+            "suggest": {
+                "drupal/facets": "Adds the ability to create faceted searches.",
+                "drupal/search_api_autocomplete": "Allows adding autocomplete suggestions to search fields.",
+                "drupal/search_api_solr": "Adds support for using Apache Solr as a backend."
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.18",
+                    "datestamp": "1603359374",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Thomas Seidl",
+                    "homepage": "https://www.drupal.org/u/drunken-monkey"
+                },
+                {
+                    "name": "Nick Veenhof",
+                    "homepage": "https://www.drupal.org/u/nick_vh"
+                },
+                {
+                    "name": "See other contributors",
+                    "homepage": "https://www.drupal.org/node/790418/committers"
+                }
+            ],
+            "description": "Provides a generic framework for modules offering search capabilities.",
+            "homepage": "https://www.drupal.org/project/search_api",
+            "support": {
+                "source": "https://git.drupalcode.org/project/search_api",
+                "issues": "https://www.drupal.org/project/issues/search_api",
+                "irc": "irc://irc.freenode.org/drupal-search-api"
             }
         },
         {


### PR DESCRIPTION
This PR re-adds the `drupal/search_api` dependency; it needs to uninstalled in Drupal first, before it can be removed from `composer.json`