### PR TITLE
(Chore) Copy after container start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,7 @@ RUN mkdir /var/log/apache2/drupal/
 COPY data/apache/000-default.conf /etc/apache2/sites-available/000-default.conf
 RUN a2enmod proxy proxy_http cache_disk headers
 
+ARG DEPLOY_ENV=prod
+ENV DEPLOY_ENV=${DEPLOY_ENV}
+
 CMD [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,15 +38,12 @@ RUN \
 RUN rm -rf ./themes && \
   ln -s /app/themes ./themes
 
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod 755 /entrypoint.sh
+COPY entrypoint.sh ./entrypoint.sh
+RUN chmod 755 ./entrypoint.sh
 
 RUN mkdir /var/log/apache2/drupal/
 
-COPY data/apache/000-default.conf /etc/apache2/sites-available/000-default.conf
+COPY ./data/apache/000-default.conf /etc/apache2/sites-available/000-default.conf
 RUN a2enmod proxy proxy_http cache_disk headers
 
-ARG DEPLOY_ENV=prod
-ENV DEPLOY_ENV=${DEPLOY_ENV}
-
-CMD [ "/entrypoint.sh" ]
+ENTRYPOINT "./entrypoint.sh"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,6 @@ services:
     tty: true # docker run -t
     build:
       context: .
-      args:
-        - DEPLOY_ENV=dev
     ports:
       - 80:80
     volumes:
@@ -52,6 +50,11 @@ services:
       - database
       - imgproxy
       - elasticsearch
+    command:
+      [
+        sh -c "sleep 60 && cp /app/shared/sites/default/dev.services.yml /app/shared/sites/default/services.yml",
+        sh -c "drush updb -y && drush cache-rebuild",
+      ]
 
   database:
     image: amsterdam/postgres11

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,10 @@ services:
   drupal:
     stdin_open: true # docker run -i
     tty: true # docker run -t
-    build: .
+    build:
+      context: .
+      args:
+        - DEPLOY_ENV=dev
     ports:
       - 80:80
     volumes:
@@ -49,11 +52,6 @@ services:
       - database
       - imgproxy
       - elasticsearch
-    command:
-      [
-        sh -c "cp /app/shared/sites/default/dev.services.yml /app/shared/sites/default/services.yml",
-        sh -c "drush updb -y && drush cache-rebuild",
-      ]
 
   database:
     image: amsterdam/postgres11

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,5 +10,10 @@ chown -R www-data:www-data /app/config
 
 chmod -R 0775 /app/shared/sites/default/
 
+if DEPLOY_ENV == "dev"; then
+  cp /app/shared/sites/default/dev.services.yml /app/shared/sites/default/services.yml && \
+  drush updb -y && drush cache-rebuild
+fi
+
 # Startup Script
 apache2-foreground

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,10 +10,5 @@ chown -R www-data:www-data /app/config
 
 chmod -R 0775 /app/shared/sites/default/
 
-if DEPLOY_ENV == "dev"; then
-  cp /app/shared/sites/default/dev.services.yml /app/shared/sites/default/services.yml && \
-  drush updb -y && drush cache-rebuild
-fi
-
 # Startup Script
 apache2-foreground


### PR DESCRIPTION
This PR makes sure that, for local development, the correct cors headers are applied. If not in place, the CMS is too restrictive and won't allow any GET request.